### PR TITLE
Add multi-agent A2A PoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# a2a
+# A2A Multi-Agent PoC
+
+This repo contains a small proof of concept showing how to build multiple
+A2A agents that communicate with each other. It defines:
+
+- `Time Agent` – returns the current UTC time.
+- `Location Agent` – returns a fixed location.
+- `Orchestrator Agent` – routes user queries to the other agents using the A2A
+  protocol and combines their responses.
+
+A minimal client is provided to test the setup.
+
+## Running the demo
+
+Install dependencies (ideally inside a virtual environment):
+
+```bash
+pip install -r requirements.txt
+```
+
+Start the agents in separate terminals:
+
+```bash
+python agents/time_agent.py
+python agents/location_agent.py
+python agents/orchestrator_agent.py
+```
+
+Query the orchestrator:
+
+```bash
+python client.py "Can you tell me the time and the location?"
+```
+
+The orchestrator fetches results from the other two agents via the A2A
+protocol and prints the combined response.

--- a/agents/location_agent.py
+++ b/agents/location_agent.py
@@ -1,0 +1,53 @@
+import uvicorn
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCard, AgentCapabilities, AgentSkill
+from a2a.utils import new_agent_text_message
+
+
+class LocationAgentExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        event_queue.enqueue_event(new_agent_text_message("New York"))
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        pass
+
+
+def build_app() -> A2AStarletteApplication:
+    skill = AgentSkill(
+        id='get_location',
+        name='Get location',
+        description='Returns a fixed location',
+        tags=['location'],
+        examples=['where are you'],
+    )
+
+    agent_card = AgentCard(
+        name='Location Agent',
+        description='Returns a fixed location',
+        url='http://localhost:8002/',
+        version='1.0',
+        defaultInputModes=['text'],
+        defaultOutputModes=['text'],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[skill],
+    )
+
+    request_handler = DefaultRequestHandler(
+        agent_executor=LocationAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+    )
+
+    return A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+    )
+
+
+if __name__ == '__main__':
+    server = build_app()
+    uvicorn.run(server.build(), host='0.0.0.0', port=8002)

--- a/agents/orchestrator_agent.py
+++ b/agents/orchestrator_agent.py
@@ -1,0 +1,106 @@
+import uvicorn
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2AClient
+from a2a.types import (
+    AgentCard,
+    AgentCapabilities,
+    AgentSkill,
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    SendMessageRequest,
+    TextPart,
+)
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.utils import get_message_text, new_agent_text_message
+
+TIME_AGENT_URL = "http://localhost:8001"
+LOCATION_AGENT_URL = "http://localhost:8002"
+
+
+class OrchestratorAgentExecutor(AgentExecutor):
+    def __init__(self) -> None:
+        self.httpx_client = httpx.AsyncClient()
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        query = context.get_user_input().lower()
+        responses: list[str] = []
+
+        if "time" in query:
+            time_client = await A2AClient.get_client_from_agent_card_url(
+                self.httpx_client, TIME_AGENT_URL
+            )
+            request = SendMessageRequest(
+                id=str(uuid4()),
+                params=MessageSendParams(message=context.message),
+            )
+            resp = await time_client.send_message(request)
+            result = resp.root.result
+            if hasattr(result, "parts"):
+                responses.append(get_message_text(result))
+
+        if "location" in query:
+            location_client = await A2AClient.get_client_from_agent_card_url(
+                self.httpx_client, LOCATION_AGENT_URL
+            )
+            request = SendMessageRequest(
+                id=str(uuid4()),
+                params=MessageSendParams(message=context.message),
+            )
+            resp = await location_client.send_message(request)
+            result = resp.root.result
+            if hasattr(result, "parts"):
+                responses.append(get_message_text(result))
+
+        if responses:
+            final_text = "\n".join(responses)
+        else:
+            final_text = "No suitable agent found"
+
+        event_queue.enqueue_event(new_agent_text_message(final_text))
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        await self.httpx_client.aclose()
+
+
+def build_app() -> A2AStarletteApplication:
+    skill = AgentSkill(
+        id="orchestrate",
+        name="Orchestrate requests",
+        description="Routes user queries to other agents",
+        tags=["orchestrator"],
+        examples=["what time is it", "where are you"],
+    )
+
+    agent_card = AgentCard(
+        name="Orchestrator Agent",
+        description="Routes queries to specialized agents",
+        url="http://localhost:9000/",
+        version="1.0",
+        defaultInputModes=["text"],
+        defaultOutputModes=["text"],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[skill],
+    )
+
+    request_handler = DefaultRequestHandler(
+        agent_executor=OrchestratorAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+    )
+
+    return A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+    )
+
+
+if __name__ == "__main__":
+    server = build_app()
+    uvicorn.run(server.build(), host="0.0.0.0", port=9000)

--- a/agents/time_agent.py
+++ b/agents/time_agent.py
@@ -1,0 +1,55 @@
+import uvicorn
+from datetime import datetime
+
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCard, AgentCapabilities, AgentSkill
+from a2a.utils import new_agent_text_message
+
+
+class TimeAgentExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        current_time = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
+        event_queue.enqueue_event(new_agent_text_message(current_time))
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        pass
+
+
+def build_app() -> A2AStarletteApplication:
+    skill = AgentSkill(
+        id='get_time',
+        name='Get current time',
+        description='Returns the current UTC time',
+        tags=['time'],
+        examples=['what time is it'],
+    )
+
+    agent_card = AgentCard(
+        name='Time Agent',
+        description='Returns the current time',
+        url='http://localhost:8001/',
+        version='1.0',
+        defaultInputModes=['text'],
+        defaultOutputModes=['text'],
+        capabilities=AgentCapabilities(streaming=False),
+        skills=[skill],
+    )
+
+    request_handler = DefaultRequestHandler(
+        agent_executor=TimeAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+    )
+
+    return A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=request_handler,
+    )
+
+
+if __name__ == '__main__':
+    server = build_app()
+    uvicorn.run(server.build(), host='0.0.0.0', port=8001)

--- a/client.py
+++ b/client.py
@@ -1,0 +1,30 @@
+import asyncio
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2AClient
+from a2a.types import Message, MessageSendParams, Part, Role, SendMessageRequest, TextPart
+
+
+async def main(query: str) -> None:
+    async with httpx.AsyncClient() as httpx_client:
+        client = await A2AClient.get_client_from_agent_card_url(httpx_client, "http://localhost:9000")
+
+        message = Message(
+            role=Role.user,
+            parts=[Part(root=TextPart(text=query))],
+            messageId=str(uuid4()),
+        )
+        request = SendMessageRequest(
+            id=str(uuid4()),
+            params=MessageSendParams(message=message),
+        )
+
+        response = await client.send_message(request)
+        print(response.model_dump_json(indent=2, exclude_none=True))
+
+
+if __name__ == "__main__":
+    import sys
+    query = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else "Can you tell me the time and the location?"
+    asyncio.run(main(query))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+a2a-sdk>=0.2.5
+httpx>=0.28
+uvicorn>=0.34


### PR DESCRIPTION
## Summary
- implement minimal TimeAgent and LocationAgent servers
- implement OrchestratorAgent that routes queries using the A2A protocol
- provide a simple client
- update README with demo instructions
- include requirements file

## Testing
- `python -m py_compile agents/time_agent.py agents/location_agent.py agents/orchestrator_agent.py client.py`
- Started servers and ran `python client.py "Can you tell me the time and the location?"`

------
https://chatgpt.com/codex/tasks/task_e_6842f23505cc83248b38b3a261541ea2